### PR TITLE
feat: framework agnostic export

### DIFF
--- a/__tests__/nav.test.tsx
+++ b/__tests__/nav.test.tsx
@@ -67,7 +67,7 @@ describe('NavBar', () => {
   const mockSetShowLeftPanel = jest.fn();
   const mockSetShowRightPanel = jest.fn();
   const mockSetPreviewMode = jest.fn();
-  
+
   const mockPage: ComponentLayer = {
     id: 'page-1',
     type: 'page',
@@ -86,14 +86,14 @@ describe('NavBar', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    
+
     // Reset window.innerWidth for each test
     Object.defineProperty(window, 'innerWidth', {
       writable: true,
       configurable: true,
       value: 1024,
     });
-    
+
     // Mock LayerStore with temporal property
     const mockLayerStore = {
       selectedPageId: 'page-1',
@@ -163,54 +163,54 @@ describe('NavBar', () => {
   describe('Basic Rendering', () => {
     it('should render the navbar with basic structure', () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const navbar = document.querySelector('.flex.items-center.justify-between.bg-background');
       expect(navbar).toBeInTheDocument();
     });
 
     it('should render undo and redo buttons', () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const undoButton = buttons.find(button => button.textContent?.includes('Undo'));
       const redoButton = buttons.find(button => button.textContent?.includes('Redo'));
-      
+
       expect(undoButton).toBeInTheDocument();
       expect(redoButton).toBeInTheDocument();
     });
 
     it('should render preview and export buttons', () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const previewButton = buttons.find(button => button.textContent?.includes('Preview'));
       const exportButton = buttons.find(button => button.textContent?.includes('Export'));
-      
+
       expect(previewButton).toBeInTheDocument();
       expect(exportButton).toBeInTheDocument();
     });
 
     it('should render theme toggle button', () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const themeButton = buttons.find(button => button.textContent?.includes('Toggle theme'));
-      
+
       expect(themeButton).toBeInTheDocument();
     });
 
     it('should render page selector button', () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       expect(screen.getByText('Test Page')).toBeInTheDocument();
     });
 
     it('should render preview mode toggle', () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const previewModeButton = buttons.find(button => button.textContent?.includes('Select screen size'));
-      
+
       expect(previewModeButton).toBeInTheDocument();
     });
   });
@@ -229,7 +229,7 @@ describe('NavBar', () => {
       });
 
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const undoButton = buttons.find(button => button.textContent?.includes('Undo'));
       expect(undoButton).toBeDisabled();
@@ -248,7 +248,7 @@ describe('NavBar', () => {
       });
 
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const undoButton = buttons.find(button => button.textContent?.includes('Undo'));
       expect(undoButton).not.toBeDisabled();
@@ -267,7 +267,7 @@ describe('NavBar', () => {
       });
 
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const redoButton = buttons.find(button => button.textContent?.includes('Redo'));
       expect(redoButton).toBeDisabled();
@@ -286,7 +286,7 @@ describe('NavBar', () => {
       });
 
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const redoButton = buttons.find(button => button.textContent?.includes('Redo'));
       expect(redoButton).not.toBeDisabled();
@@ -305,12 +305,12 @@ describe('NavBar', () => {
       });
 
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const undoButton = buttons.find(button => button.textContent?.includes('Undo'));
       if (undoButton) {
         fireEvent.click(undoButton);
-        
+
         expect(mockUndo).toHaveBeenCalled();
         expect(mockIncrementRevision).toHaveBeenCalled();
       }
@@ -329,12 +329,12 @@ describe('NavBar', () => {
       });
 
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const redoButton = buttons.find(button => button.textContent?.includes('Redo'));
       if (redoButton) {
         fireEvent.click(redoButton);
-        
+
         expect(mockRedo).toHaveBeenCalled();
         expect(mockIncrementRevision).toHaveBeenCalled();
       }
@@ -344,13 +344,13 @@ describe('NavBar', () => {
   describe('Preview Dialog', () => {
     it('should open preview dialog when preview button is clicked', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const previewButton = buttons.find(button => button.textContent?.includes('Preview'));
-      
+
       if (previewButton) {
         fireEvent.click(previewButton);
-        
+
         await waitFor(() => {
           expect(screen.getByText('Page Preview')).toBeInTheDocument();
         });
@@ -359,13 +359,13 @@ describe('NavBar', () => {
 
     it('should close preview dialog when close button is clicked', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const previewButton = buttons.find(button => button.textContent?.includes('Preview'));
-      
+
       if (previewButton) {
         fireEvent.click(previewButton);
-        
+
         await waitFor(() => {
           expect(screen.getByText('Page Preview')).toBeInTheDocument();
         });
@@ -374,7 +374,7 @@ describe('NavBar', () => {
         const closeButton = closeButtons.find(button => button.textContent?.includes('Close'));
         if (closeButton) {
           fireEvent.click(closeButton);
-          
+
           await waitFor(() => {
             expect(screen.queryByText('Page Preview')).not.toBeInTheDocument();
           });
@@ -386,13 +386,13 @@ describe('NavBar', () => {
   describe('Code Export Dialog', () => {
     it('should open export dialog when export button is clicked', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
-      const exportButton = buttons.find(button => button.textContent?.includes('Export'));
-      
+      const exportButton = buttons.find(button => button.textContent?.includes('Export Code'));
+
       if (exportButton) {
         fireEvent.click(exportButton);
-        
+
         await waitFor(() => {
           expect(screen.getByText('Generated Code')).toBeInTheDocument();
         });
@@ -401,13 +401,13 @@ describe('NavBar', () => {
 
     it('should close export dialog when close button is clicked', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const exportButton = buttons.find(button => button.textContent?.includes('Export'));
-      
+
       if (exportButton) {
         fireEvent.click(exportButton);
-        
+
         await waitFor(() => {
           expect(screen.getByText('Generated Code')).toBeInTheDocument();
         });
@@ -416,7 +416,7 @@ describe('NavBar', () => {
         const closeButton = closeButtons.find(button => button.textContent?.includes('Close'));
         if (closeButton) {
           fireEvent.click(closeButton);
-          
+
           await waitFor(() => {
             expect(screen.queryByText('Generated Code')).not.toBeInTheDocument();
           });
@@ -428,7 +428,7 @@ describe('NavBar', () => {
   describe('Theme Toggle', () => {
     it('should render theme toggle with light and dark icons', () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const themeButton = buttons.find(button => button.textContent?.includes('Toggle theme'));
       expect(themeButton).toBeInTheDocument();
@@ -436,13 +436,13 @@ describe('NavBar', () => {
 
     it('should open theme dropdown when clicked', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const themeButton = buttons.find(button => button.textContent?.includes('Toggle theme'));
-      
+
       if (themeButton) {
         fireEvent.click(themeButton);
-        
+
         await waitFor(async () => {
           const dropdownItems = screen.queryAllByText('Light');
           if (dropdownItems.length > 0) {
@@ -458,13 +458,13 @@ describe('NavBar', () => {
 
     it('should call setTheme with light when Light option is clicked', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const themeButton = buttons.find(button => button.textContent?.includes('Toggle theme'));
-      
+
       if (themeButton) {
         fireEvent.click(themeButton);
-        
+
         await waitFor(async () => {
           const lightOption = screen.queryByText('Light');
           if (lightOption) {
@@ -477,13 +477,13 @@ describe('NavBar', () => {
 
     it('should call setTheme with dark when Dark option is clicked', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const themeButton = buttons.find(button => button.textContent?.includes('Toggle theme'));
-      
+
       if (themeButton) {
         fireEvent.click(themeButton);
-        
+
         await waitFor(async () => {
           const darkOption = screen.queryByText('Dark');
           if (darkOption) {
@@ -496,13 +496,13 @@ describe('NavBar', () => {
 
     it('should call setTheme with system when System option is clicked', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const themeButton = buttons.find(button => button.textContent?.includes('Toggle theme'));
-      
+
       if (themeButton) {
         fireEvent.click(themeButton);
-        
+
         await waitFor(async () => {
           const systemOption = screen.queryByText('System');
           if (systemOption) {
@@ -517,22 +517,22 @@ describe('NavBar', () => {
   describe('Preview Mode Toggle', () => {
     it('should render preview mode toggle button', () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const previewModeButton = buttons.find(button => button.textContent?.includes('Select screen size'));
-      
+
       expect(previewModeButton).toBeInTheDocument();
     });
 
     it('should open preview mode dropdown when clicked', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const previewModeButton = buttons.find(button => button.textContent?.includes('Select screen size'));
-      
+
       if (previewModeButton) {
         fireEvent.click(previewModeButton);
-        
+
         await waitFor(async () => {
           const mobileOption = screen.queryByText('Mobile');
           if (mobileOption) {
@@ -546,13 +546,13 @@ describe('NavBar', () => {
 
     it('should call setPreviewMode with mobile when Mobile option is clicked', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const previewModeButton = buttons.find(button => button.textContent?.includes('Select screen size'));
-      
+
       if (previewModeButton) {
         fireEvent.click(previewModeButton);
-        
+
         await waitFor(async () => {
           const mobileOption = screen.queryByText('Mobile');
           if (mobileOption) {
@@ -565,13 +565,13 @@ describe('NavBar', () => {
 
     it('should call setPreviewMode with tablet when Tablet option is clicked', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const previewModeButton = buttons.find(button => button.textContent?.includes('Select screen size'));
-      
+
       if (previewModeButton) {
         fireEvent.click(previewModeButton);
-        
+
         await waitFor(async () => {
           const tabletOption = screen.queryByText('Tablet');
           if (tabletOption) {
@@ -584,13 +584,13 @@ describe('NavBar', () => {
 
     it('should call setPreviewMode with desktop when Desktop option is clicked', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const previewModeButton = buttons.find(button => button.textContent?.includes('Select screen size'));
-      
+
       if (previewModeButton) {
         fireEvent.click(previewModeButton);
-        
+
         await waitFor(async () => {
           const desktopOption = screen.queryByText('Desktop');
           if (desktopOption) {
@@ -603,13 +603,13 @@ describe('NavBar', () => {
 
     it('should call setPreviewMode with responsive when Responsive option is clicked', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const previewModeButton = buttons.find(button => button.textContent?.includes('Select screen size'));
-      
+
       if (previewModeButton) {
         fireEvent.click(previewModeButton);
-        
+
         await waitFor(async () => {
           const responsiveOption = screen.queryByText('Responsive');
           if (responsiveOption) {
@@ -624,16 +624,16 @@ describe('NavBar', () => {
   describe('Pages Popover', () => {
     it('should render current page name in button', () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       expect(screen.getByText('Test Page')).toBeInTheDocument();
     });
 
     it('should open pages popover when page button is clicked', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const pageButton = screen.getByText('Test Page');
       fireEvent.click(pageButton);
-      
+
       await waitFor(() => {
         expect(screen.getByPlaceholderText('Select page or create new...')).toBeInTheDocument();
       });
@@ -667,10 +667,10 @@ describe('NavBar', () => {
       });
 
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const pageButton = screen.getByText('Test Page');
       fireEvent.click(pageButton);
-      
+
       await waitFor(() => {
         const pageItems = screen.getAllByText('Test Page');
         const page2Items = screen.getAllByText('Page 2');
@@ -681,10 +681,10 @@ describe('NavBar', () => {
 
     it('should allow creating new pages when allowPagesCreation is true', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const pageButton = screen.getByText('Test Page');
       fireEvent.click(pageButton);
-      
+
       await waitFor(() => {
         expect(screen.getByPlaceholderText('New page name...')).toBeInTheDocument();
       });
@@ -692,14 +692,14 @@ describe('NavBar', () => {
 
     it('should create new page when form is submitted', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const pageButton = screen.getByText('Test Page');
       fireEvent.click(pageButton);
-      
+
       await waitFor(() => {
         const input = screen.getByPlaceholderText('New page name...');
         fireEvent.change(input, { target: { value: 'New Page' } });
-        
+
         const form = input.closest('form');
         if (form) {
           fireEvent.submit(form);
@@ -710,15 +710,15 @@ describe('NavBar', () => {
 
     it('should create new page when Enter key is pressed', async () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const pageButton = screen.getByText('Test Page');
       fireEvent.click(pageButton);
-      
+
       await waitFor(() => {
         const input = screen.getByPlaceholderText('New page name...');
         fireEvent.change(input, { target: { value: 'Another Page' } });
         fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
-        
+
         expect(mockAddPageLayer).toHaveBeenCalledWith('Another Page');
       });
     });
@@ -751,16 +751,16 @@ describe('NavBar', () => {
       });
 
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const pageButton = screen.getByText('Test Page');
       fireEvent.click(pageButton);
-      
+
       await waitFor(() => {
         const page2Items = screen.getAllByText('Page 2');
-        const selectablePage2 = page2Items.find(item => 
+        const selectablePage2 = page2Items.find(item =>
           item.closest('[cmdk-item]') || item.closest('[role="option"]')
         );
-        
+
         if (selectablePage2) {
           fireEvent.click(selectablePage2);
           expect(mockSelectPage).toHaveBeenCalledWith('page-2');
@@ -772,7 +772,7 @@ describe('NavBar', () => {
   describe('Panel Toggles', () => {
     it('should render left panel toggle button', () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const leftPanelButton = buttons.find(button => button.textContent?.includes('Toggle Left Panel'));
       expect(leftPanelButton).toBeInTheDocument();
@@ -780,7 +780,7 @@ describe('NavBar', () => {
 
     it('should render right panel toggle button', () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const rightPanelButton = buttons.find(button => button.textContent?.includes('Toggle Right Panel'));
       expect(rightPanelButton).toBeInTheDocument();
@@ -788,10 +788,10 @@ describe('NavBar', () => {
 
     it('should toggle left panel when left panel button is clicked', () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const leftPanelButton = buttons.find(button => button.textContent?.includes('Toggle Left Panel'));
-      
+
       if (leftPanelButton) {
         fireEvent.click(leftPanelButton);
         expect(mockSetShowLeftPanel).toHaveBeenCalledWith(false); // Since showLeftPanel is true by default
@@ -800,10 +800,10 @@ describe('NavBar', () => {
 
     it('should toggle right panel when right panel button is clicked', () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const rightPanelButton = buttons.find(button => button.textContent?.includes('Toggle Right Panel'));
-      
+
       if (rightPanelButton) {
         fireEvent.click(rightPanelButton);
         expect(mockSetShowRightPanel).toHaveBeenCalledWith(false); // Since showRightPanel is true by default
@@ -831,11 +831,11 @@ describe('NavBar', () => {
       });
 
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const leftPanelButton = buttons.find(button => button.textContent?.includes('Toggle Left Panel'));
       const rightPanelButton = buttons.find(button => button.textContent?.includes('Toggle Right Panel'));
-      
+
       expect(leftPanelButton).toBeInTheDocument();
       expect(rightPanelButton).toBeInTheDocument();
     });
@@ -850,7 +850,7 @@ describe('NavBar', () => {
       });
 
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const moreButton = buttons.find(button => button.textContent?.includes('Actions'));
       expect(moreButton).toBeInTheDocument();
@@ -864,13 +864,13 @@ describe('NavBar', () => {
       });
 
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const moreButton = buttons.find(button => button.textContent?.includes('Actions'));
-      
+
       if (moreButton) {
         fireEvent.click(moreButton);
-        
+
         await waitFor(() => {
           const undoOption = screen.queryByText('Undo');
           if (undoOption) {
@@ -899,19 +899,19 @@ describe('NavBar', () => {
       });
 
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const moreButton = buttons.find(button => button.textContent?.includes('Actions'));
-      
+
       if (moreButton) {
         fireEvent.click(moreButton);
-        
+
         await waitFor(async () => {
           const undoOptions = screen.queryAllByText('Undo');
-          const clickableUndo = undoOptions.find(option => 
+          const clickableUndo = undoOptions.find(option =>
             option.closest('[role="menuitem"]') || option.closest('[cmdk-item]')
           );
-          
+
           if (clickableUndo) {
             fireEvent.click(clickableUndo);
             expect(mockUndo).toHaveBeenCalled();
@@ -925,15 +925,15 @@ describe('NavBar', () => {
   describe('Keyboard Shortcuts', () => {
     it('should register keyboard shortcuts', () => {
       const { useKeyboardShortcuts } = require('@/hooks/use-keyboard-shortcuts');
-      
+
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       expect(useKeyboardShortcuts).toHaveBeenCalled();
-      
+
       // Check that the shortcuts include undo and redo
       const call = useKeyboardShortcuts.mock.calls[0];
       const shortcuts = call[0];
-      
+
       expect(shortcuts).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
@@ -950,12 +950,12 @@ describe('NavBar', () => {
 
     it('should register fun keyboard shortcuts for animations', () => {
       const { useKeyboardShortcuts } = require('@/hooks/use-keyboard-shortcuts');
-      
+
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const call = useKeyboardShortcuts.mock.calls[0];
       const shortcuts = call[0];
-      
+
       expect(shortcuts).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
@@ -974,9 +974,9 @@ describe('NavBar', () => {
   describe('Edge Cases', () => {
     it('should handle missing page gracefully', () => {
       mockFindLayerById.mockReturnValue(null);
-      
+
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       // Should not crash
       expect(screen.getByRole('button', { name: /toggle theme/i })).toBeInTheDocument();
     });
@@ -1008,7 +1008,7 @@ describe('NavBar', () => {
       mockFindLayerById.mockReturnValue(null);
 
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       // Should render without crashing
       expect(screen.getByRole('button', { name: /toggle theme/i })).toBeInTheDocument();
     });
@@ -1034,10 +1034,10 @@ describe('NavBar', () => {
       });
 
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const pageButton = screen.getByText('Test Page');
       fireEvent.click(pageButton);
-      
+
       await waitFor(() => {
         // Should not show the new page input when creation is disabled
         expect(screen.queryByPlaceholderText('New page name...')).not.toBeInTheDocument();
@@ -1048,14 +1048,14 @@ describe('NavBar', () => {
   describe('Data Test IDs', () => {
     it('should have proper accessibility labels', () => {
       render(<NavBar />, { wrapper: TestWrapper });
-      
+
       const buttons = screen.getAllByRole('button');
       const undoButton = buttons.find(button => button.textContent?.includes('Undo'));
       const redoButton = buttons.find(button => button.textContent?.includes('Redo'));
       const previewButton = buttons.find(button => button.textContent?.includes('Preview'));
       const exportButton = buttons.find(button => button.textContent?.includes('Export'));
       const themeButton = buttons.find(button => button.textContent?.includes('Toggle theme'));
-      
+
       expect(undoButton).toBeInTheDocument();
       expect(redoButton).toBeInTheDocument();
       expect(previewButton).toBeInTheDocument();

--- a/app/api/getTailwindConfig/route.ts
+++ b/app/api/getTailwindConfig/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import tailwindConfig from "../../../tailwind.config.js";
+
+export async function GET() {
+  try {
+    return NextResponse.json({
+      data: tailwindConfig,
+    });
+  } catch (err) {
+    console.error("Error loading tailwind config:", err);
+    return NextResponse.json({
+      success: false,
+      error: "Failed to load tailwind config",
+    });
+  }
+}

--- a/app/platform/builder-with-immutable-bindings.tsx
+++ b/app/platform/builder-with-immutable-bindings.tsx
@@ -1,12 +1,10 @@
 "use client"
 
-import React from "react";
 import UIBuilder from "@/components/ui/ui-builder";
-import { demoComponentRegistry } from "./demo-components";
-import { primitiveComponentDefinitions } from "@/lib/ui-builder/registry/primitive-component-definitions";
-import { complexComponentDefinitions } from "@/lib/ui-builder/registry/complex-component-definitions";
 import { ComponentLayer, Variable } from '@/components/ui/ui-builder/types';
-import { useLayerStore } from "@/lib/ui-builder/store/layer-store";
+import { complexComponentDefinitions } from "@/lib/ui-builder/registry/complex-component-definitions";
+import { primitiveComponentDefinitions } from "@/lib/ui-builder/registry/primitive-component-definitions";
+import { demoComponentRegistry } from "./demo-components";
 
 // Initial page structure showcasing immutable bindings
 const initialLayers: ComponentLayer[] = [{
@@ -36,7 +34,7 @@ const initialLayers: ComponentLayer[] = [{
         },
         {
           "id": "subtitle",
-          "type": "span", 
+          "type": "span",
           "name": "Subtitle",
           "props": {
             "className": "text-lg text-gray-600 block mb-8"
@@ -56,7 +54,7 @@ const initialLayers: ComponentLayer[] = [{
         {
           "id": "user-profile-section",
           "type": "div",
-          "name": "User Profile Section", 
+          "name": "User Profile Section",
           "props": {
             "className": "space-y-4"
           },
@@ -104,7 +102,7 @@ const initialLayers: ComponentLayer[] = [{
             {
               "id": "button-section-title",
               "type": "span",
-              "name": "Button Section Title", 
+              "name": "Button Section Title",
               "props": {
                 "className": "text-2xl font-semibold text-gray-800 block"
               },
@@ -129,7 +127,7 @@ const initialLayers: ComponentLayer[] = [{
               "children": [
                 {
                   "id": "primary-button-demo",
-                  "type": "BrandedButton", 
+                  "type": "BrandedButton",
                   "name": "Primary Button",
                   "props": {
                     "text": { "__variableRef": "button_text" },
@@ -143,7 +141,7 @@ const initialLayers: ComponentLayer[] = [{
                 {
                   "id": "secondary-button-demo",
                   "type": "BrandedButton",
-                  "name": "Secondary Button", 
+                  "name": "Secondary Button",
                   "props": {
                     "text": "Learn More",
                     "brandColor": { "__variableRef": "company_brand_color" },
@@ -175,7 +173,7 @@ const initialLayers: ComponentLayer[] = [{
               "children": "⚠️ System Alert Component"
             },
             {
-              "id": "alert-description", 
+              "id": "alert-description",
               "type": "span",
               "name": "Alert Description",
               "props": {
@@ -227,7 +225,7 @@ const initialLayers: ComponentLayer[] = [{
             {
               "id": "instruction-1",
               "type": "span",
-              "name": "Instruction 1", 
+              "name": "Instruction 1",
               "props": {
                 "className": "block"
               },
@@ -252,7 +250,7 @@ const initialLayers: ComponentLayer[] = [{
               "children": "3. Notice the 🔗 variable binding indicators and 🔒 'Immutable' badges"
             },
             {
-              "id": "instruction-4", 
+              "id": "instruction-4",
               "type": "span",
               "name": "Instruction 4",
               "props": {
@@ -263,7 +261,7 @@ const initialLayers: ComponentLayer[] = [{
             {
               "id": "instruction-5",
               "type": "span",
-              "name": "Instruction 5", 
+              "name": "Instruction 5",
               "props": {
                 "className": "block"
               },
@@ -286,7 +284,7 @@ const initialVariables: Variable[] = [
     defaultValue: "usr_789xyz"
   },
   {
-    id: "current_user_name", 
+    id: "current_user_name",
     name: "Current User Name",
     type: "string",
     defaultValue: "Alex Rivera"
@@ -294,7 +292,7 @@ const initialVariables: Variable[] = [
   {
     id: "current_user_email",
     name: "Current User Email",
-    type: "string", 
+    type: "string",
     defaultValue: "alex.rivera@company.com"
   },
   {
@@ -313,7 +311,7 @@ const initialVariables: Variable[] = [
   },
   {
     id: "company_name",
-    name: "Company Name", 
+    name: "Company Name",
     type: "string",
     defaultValue: "TechCorp Inc."
   },
@@ -334,7 +332,7 @@ const initialVariables: Variable[] = [
   {
     id: "maintenance_mode",
     name: "Maintenance Mode",
-    type: "boolean", 
+    type: "boolean",
     defaultValue: false
   },
   {
@@ -351,7 +349,7 @@ export const BuilderWithImmutableBindings = () => {
   };
 
   return (
-    <UIBuilder 
+    <UIBuilder
       initialLayers={initialLayers}
       initialVariables={initialVariables}
       componentRegistry={{

--- a/components/ui/ui-builder/internal/components/nav.tsx
+++ b/components/ui/ui-builder/internal/components/nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useCallback, useMemo, useState } from "react";
+import { forwardRef, useCallback, useMemo, useState, useEffect, Dispatch, SetStateAction } from "react";
 import {
   Eye,
   FileUp,
@@ -86,6 +86,8 @@ const Z_INDEX = 1000;
 
 
 export function NavBar() {
+  const [tailwindConfig, setTailwindConfig] = useState<Tailwind | null>(null);
+
   const selectedPageId = useLayerStore((state) => state.selectedPageId);
   const findLayerById = useLayerStore((state) => state.findLayerById);
   const componentRegistry = useEditorStore((state) => state.registry);
@@ -227,7 +229,7 @@ export function NavBar() {
         </div>
         <div className="hidden md:flex h-10 w-px bg-border"></div>
         <PagesPopover />
-        <ExportProjectFeature />
+        <ExportProjectFeature tailwindConfig={tailwindConfig} setTailwindConfig={setTailwindConfig} />
         <PreviewModeToggle />
       </div>
 
@@ -544,28 +546,32 @@ const CodeDialog: React.FC<CodeDialogProps> = ({ isOpen, onOpenChange }) => {
     </Dialog>
   );
 };
-function ExportProjectFeature() {
+
+function ExportProjectFeature({ tailwindConfig, setTailwindConfig }: { tailwindConfig: Tailwind | null, setTailwindConfig: Dispatch<SetStateAction<Tailwind | null>> }) {
   const { pages } = useLayerStore();
-  let tailwindConfiguration: Tailwind | null = null;
+
+  // let tailwindConfiguration: Tailwind | null = null;
 
   const fetchTailwindConfiguration = () =>
     axios
       .get("/api/getTailwindConfig")
       .then((response) => {
-        console.log(tailwindConfiguration, "tailwindConfig");
-        tailwindConfiguration = response.data.data.plugins[0];
+        console.log(response, "response from call")
+        setTailwindConfig(response.data.data.plugins[0])
       })
       .catch((err) => {
         console.error("Error fetching config:", err);
         return err;
       });
 
-  fetchTailwindConfiguration()
+  useEffect(() => {
+    fetchTailwindConfiguration()
+  }, [])
 
   const exportProject = useCallback(() => {
     const registryItem = generateRegistryItem({
       name: "MyProject",
-      tailwindConfiguration,
+      tailwindConfig,
       pages
     });
     console.log(registryItem, "registryItem");
@@ -582,7 +588,7 @@ function ExportProjectFeature() {
 
     console.log('Registry item generated:', registryItem);
     console.log('You can now use this with: npx shadcn@latest init <your-api-endpoint>');
-  }, [pages])
+  }, [pages, tailwindConfig])
 
   return (
     <div className="p-4 border rounded-lg bg-muted/50">

--- a/components/ui/ui-builder/internal/components/nav.tsx
+++ b/components/ui/ui-builder/internal/components/nav.tsx
@@ -556,8 +556,7 @@ function ExportProjectFeature({ tailwindConfig, setTailwindConfig }: { tailwindC
     axios
       .get("/api/getTailwindConfig")
       .then((response) => {
-        console.log(response, "response from call")
-        setTailwindConfig(response.data.data.plugins[0])
+        setTailwindConfig(response.data.data)
       })
       .catch((err) => {
         console.error("Error fetching config:", err);

--- a/components/ui/ui-builder/internal/components/nav.tsx
+++ b/components/ui/ui-builder/internal/components/nav.tsx
@@ -552,20 +552,22 @@ function ExportProjectFeature({ tailwindConfig, setTailwindConfig }: { tailwindC
 
   // let tailwindConfiguration: Tailwind | null = null;
 
-  const fetchTailwindConfiguration = () =>
-    axios
-      .get("/api/getTailwindConfig")
-      .then((response) => {
-        setTailwindConfig(response.data.data)
-      })
-      .catch((err) => {
-        console.error("Error fetching config:", err);
-        return err;
-      });
+
 
   useEffect(() => {
+    const fetchTailwindConfiguration = () =>
+      axios
+        .get("/api/getTailwindConfig")
+        .then((response) => {
+          console.log(response?.data?.data, "response from call")
+          setTailwindConfig(response.data.data)
+        })
+        .catch((err) => {
+          console.error("Error fetching config:", err);
+          return err;
+        });
     fetchTailwindConfiguration()
-  }, [])
+  }, [setTailwindConfig])
 
   const exportProject = useCallback(() => {
     const registryItem = generateRegistryItem({

--- a/components/ui/ui-builder/internal/editor-panel.tsx
+++ b/components/ui/ui-builder/internal/editor-panel.tsx
@@ -256,7 +256,7 @@ const EditorPanelContent: React.FC<EditorPanelContentProps> = ({
     setPointerEventsEnabled(enabled);
   }, []);
 
-  let layers: string | ComponentLayer<Record<string, PropValue>>[] | null = '';
+  let layers: string | ComponentLayer<Record<string, PropValue>>[] = '';
   if (selectedPage && selectedPage?.children) {
     layers = selectedPage.children;
   }

--- a/components/ui/ui-builder/internal/editor-panel.tsx
+++ b/components/ui/ui-builder/internal/editor-panel.tsx
@@ -8,7 +8,7 @@ import React, {
 } from "react";
 import { Plus, Crosshair, ZoomIn, ZoomOut, MousePointer } from "lucide-react";
 import { countLayers, useLayerStore } from "@/lib/ui-builder/store/layer-store";
-import { ComponentLayer } from "@/components/ui/ui-builder/types";
+import { ComponentLayer, PropValue } from "@/components/ui/ui-builder/types";
 import {
   TransformWrapper,
   TransformComponent,
@@ -44,9 +44,9 @@ const TRANSFORM_DIV_STYLE = {
 const WHEEL_CONFIG = { step: 0.1 } as const;
 const DOUBLE_CLICK_CONFIG = { disabled: false } as const;
 
-const ZoomControls: React.FC<{ onPointerEventsToggle: (enabled: boolean) => void; pointerEventsEnabled: boolean }> = ({ 
-  onPointerEventsToggle, 
-  pointerEventsEnabled 
+const ZoomControls: React.FC<{ onPointerEventsToggle: (enabled: boolean) => void; pointerEventsEnabled: boolean }> = ({
+  onPointerEventsToggle,
+  pointerEventsEnabled
 }) => {
   const { zoomIn, zoomOut, resetTransform } = useControls();
 
@@ -76,7 +76,7 @@ const ZoomControls: React.FC<{ onPointerEventsToggle: (enabled: boolean) => void
             <p>Zoom in</p>
           </TooltipContent>
         </Tooltip>
-        
+
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -93,7 +93,7 @@ const ZoomControls: React.FC<{ onPointerEventsToggle: (enabled: boolean) => void
             <p>Zoom out</p>
           </TooltipContent>
         </Tooltip>
-        
+
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -110,7 +110,7 @@ const ZoomControls: React.FC<{ onPointerEventsToggle: (enabled: boolean) => void
             <p>Reset zoom and position</p>
           </TooltipContent>
         </Tooltip>
-        
+
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -220,7 +220,7 @@ interface EditorPanelContentProps {
 }
 
 // Inner component that can access ComponentDragContext
-const EditorPanelContent: React.FC<EditorPanelContentProps> = ({ 
+const EditorPanelContent: React.FC<EditorPanelContentProps> = ({
   className,
   selectedPageId,
   selectedLayerId,
@@ -237,13 +237,13 @@ const EditorPanelContent: React.FC<EditorPanelContentProps> = ({
 }) => {
   const { isDragging: isComponentDragging } = useComponentDragContext();
   const [resizing, setResizing] = useState(false);
-  const [frameSize, setFrameSize] = useState<{ width: number; height: number }>({ 
-    width: 1000, 
-    height: 1000 
+  const [frameSize, setFrameSize] = useState<{ width: number; height: number }>({
+    width: 1000,
+    height: 1000
   });
   const [pointerEventsEnabled, setPointerEventsEnabled] = useState(true);
   const frameRef = useRef<HTMLIFrameElement>(null);
-  
+
   const handleResizingChange = useCallback((isDragging: boolean) => {
     setResizing(isDragging);
   }, []);
@@ -256,11 +256,14 @@ const EditorPanelContent: React.FC<EditorPanelContentProps> = ({
     setPointerEventsEnabled(enabled);
   }, []);
 
-  const layers = selectedPage.children;
+  let layers: string | ComponentLayer<Record<string, PropValue>>[] | null = '';
+  if (selectedPage && selectedPage?.children) {
+    layers = selectedPage.children;
+  }
 
   // Memoize totalLayers calculation separately to avoid recalculating on every render
   const totalLayers = useMemo(() => countLayers(layers), [layers]);
-  
+
   const editorConfig = useMemo(
     () => ({
       zIndex: 1,
@@ -354,7 +357,7 @@ const EditorPanelContent: React.FC<EditorPanelContentProps> = ({
     [resizableProps, widthClass, autoFrameProps, layerRendererProps]
   );
 
-  
+
   // Use static objects for consistent styles (defined outside component would be better)
   const wrapperStyle = WRAPPER_STYLE;
   const contentStyle = CONTENT_STYLE;
@@ -363,8 +366,8 @@ const EditorPanelContent: React.FC<EditorPanelContentProps> = ({
   const doubleClickConfig = DOUBLE_CLICK_CONFIG;
 
   // Disable panning when either resizing the viewport OR dragging components
-  const panningConfig = useMemo(() => ({ 
-    disabled: resizing || isComponentDragging 
+  const panningConfig = useMemo(() => ({
+    disabled: resizing || isComponentDragging
   }), [resizing, isComponentDragging]);
 
   return (
@@ -387,14 +390,14 @@ const EditorPanelContent: React.FC<EditorPanelContentProps> = ({
         centerOnInit={false}
         limitToBounds={false}
       >
-        <ZoomControls 
+        <ZoomControls
           onPointerEventsToggle={handlePointerEventsToggle}
           pointerEventsEnabled={pointerEventsEnabled}
         />
-        {autoZoomToSelected && <AutoZoomToSelected 
-            selectedLayerId={selectedLayerId} 
-            autoZoomToSelected={autoZoomToSelected} 
-          /> }
+        {autoZoomToSelected && <AutoZoomToSelected
+          selectedLayerId={selectedLayerId}
+          autoZoomToSelected={autoZoomToSelected}
+        />}
         <TransformComponent
           wrapperStyle={wrapperStyle}
           contentStyle={contentStyle}

--- a/components/ui/ui-builder/internal/utils/render-utils.tsx
+++ b/components/ui/ui-builder/internal/utils/render-utils.tsx
@@ -49,7 +49,7 @@ export const RenderLayer: React.FC<{
     const isLayerAPage = useLayerStore((state) => state.isLayerAPage(layer.id));
     const registry = useEditorStore((state) => state.registry);
     const dndContext = useSafeDndContext();
-    
+
     // Use provided variables or fall back to store variables
     const effectiveVariables = variables || storeVariables;
     const componentDefinition =
@@ -66,13 +66,12 @@ export const RenderLayer: React.FC<{
     }), [layer, componentRegistry]);
 
     // Resolve variable references in props with proper memoization
-    const resolvedProps = useMemo(() => 
+    const resolvedProps = useMemo(() =>
       resolveVariableReferences(layer.props, effectiveVariables, variableValues),
       [layer.props, effectiveVariables, variableValues]
     );
-    
+
     const childProps: Record<string, PropValue> = useMemo(() => ({ ...resolvedProps }), [resolvedProps]);
-    
     // Memoize child editor config to avoid creating objects in JSX
     const childEditorConfig = useMemo(() => {
       return editorConfig
@@ -82,16 +81,13 @@ export const RenderLayer: React.FC<{
 
     // Check if this layer can accept children and if drag is active (must be before early returns)
     const canAcceptChildren = useMemo(() => canLayerAcceptChildren(layer, registry), [layer, registry]);
-    const showDropZones = useMemo(() => 
+    const showDropZones = useMemo(() =>
       editorConfig && dndContext?.isDragging && canAcceptChildren,
       [editorConfig, dndContext?.isDragging, canAcceptChildren]
     );
 
     if (!componentDefinition) {
-      console.error(
-        `[UIBuilder] Component definition not found in registry:`, 
-        infoData
-      );
+
       return null;
     }
 
@@ -104,7 +100,7 @@ export const RenderLayer: React.FC<{
     }
 
     if (!Component) return null;
-    
+
     // Handle children rendering with improved drop zones
     if (hasLayerChildren(layer) && layer.children.length > 0) {
       const childElements = layer.children.map((child, index) => {
@@ -211,7 +207,7 @@ export const RenderLayer: React.FC<{
     }
   },
   (prevProps, nextProps) => {
-    if(nextProps.editorConfig?.parentUpdated) {
+    if (nextProps.editorConfig?.parentUpdated) {
       return false;
     }
     const editorConfigEqual = isDeepEqual(
@@ -230,7 +226,7 @@ const ErrorSuspenseWrapper: React.FC<{
   children: React.ReactNode;
 }> = ({ children }) => {
   const loadingFallback = useMemo(() => <LoadingComponent />, []);
-  
+
   return (
     <ErrorBoundary fallbackRender={ErrorFallback}>
       <Suspense fallback={loadingFallback}>{children}</Suspense>

--- a/components/ui/ui-builder/types.ts
+++ b/components/ui/ui-builder/types.ts
@@ -1,48 +1,54 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ZodObject, ZodSchema } from "zod";
-import { ComponentType as ReactComponentType, ReactNode } from 'react';
-import {
-    FieldConfigItem,
-  } from "@/components/ui/auto-form/types";
+import { Config, PluginCreator } from "tailwindcss/types/config";
+
+import { ComponentType as ReactComponentType, ReactNode } from "react";
+import { FieldConfigItem } from "@/components/ui/auto-form/types";
 
 export type {
-    AutoFormInputComponentProps,
-    FieldConfigItem,
-  } from "@/components/ui/auto-form/types";
+  AutoFormInputComponentProps,
+  FieldConfigItem,
+} from "@/components/ui/auto-form/types";
 
 // Enhanced prop value types that can accommodate React props, variables, and common data types
-export type PropValue = 
-  | ReactNode 
-  | VariableReference 
-  | Record<string, any> 
-  | any[] 
-  | string 
-  | number 
-  | boolean 
-  | null 
+export type PropValue =
+  | ReactNode
+  | VariableReference
+  | Record<string, any>
+  | any[]
+  | string
+  | number
+  | boolean
+  | null
   | undefined;
 
 // Generic component props that allow for flexible but safer typing
-export type ComponentProps<TProps extends Record<string, PropValue> = Record<string, PropValue>> = TProps;
+export type ComponentProps<
+  TProps extends Record<string, PropValue> = Record<string, PropValue>,
+> = TProps;
 
 // Enhanced ComponentLayer with generic prop typing
-export interface ComponentLayer<TProps extends Record<string, PropValue> = Record<string, PropValue>> {
-    id: string;
-    name?: string;
-    type: string;
-    props: ComponentProps<TProps>;
-    children: ComponentLayer[] | string;
+export interface ComponentLayer<
+  TProps extends Record<string, PropValue> = Record<string, PropValue>,
+> {
+  id: string;
+  name?: string;
+  type: string;
+  props: ComponentProps<TProps>;
+  children: ComponentLayer[] | string;
 }
 
 // Variable value types - more specific than before
-export type VariableValueType = 'string' | 'number' | 'boolean';
+export type VariableValueType = "string" | "number" | "boolean";
 
 // Type-safe variable values based on their type
-export type VariableValue<T extends VariableValueType> = 
-  T extends 'string' ? string :
-  T extends 'number' ? number :
-  T extends 'boolean' ? boolean :
-  never;
+export type VariableValue<T extends VariableValueType> = T extends "string"
+  ? string
+  : T extends "number"
+  ? number
+  : T extends "boolean"
+  ? boolean
+  : never;
 
 // Enhanced Variable interface with generic typing
 export interface Variable<T extends VariableValueType = VariableValueType> {
@@ -76,33 +82,49 @@ export interface RegistryEntry<T extends ReactComponentType<any>> {
 }
 
 // Improved field config function type
-export type FieldConfigFunction = (layer: ComponentLayer, allowVariableBinding?: boolean) => FieldConfigItem;
+export type FieldConfigFunction = (
+  layer: ComponentLayer,
+  allowVariableBinding?: boolean
+) => FieldConfigItem;
 
 // Enhanced ComponentRegistry with better typing
-export type ComponentRegistry = Record<string, RegistryEntry<ReactComponentType<any>>>;
+export type ComponentRegistry = Record<
+  string,
+  RegistryEntry<ReactComponentType<any>>
+>;
 
 // Type-safe layer change handler with registry awareness
-export type LayerChangeHandler<TRegistry extends ComponentRegistry = ComponentRegistry> = 
-  (layers: Array<ComponentLayer & {
-    type: keyof TRegistry;
-  }>) => void;
+export type LayerChangeHandler<
+  TRegistry extends ComponentRegistry = ComponentRegistry,
+> = (
+  layers: Array<
+    ComponentLayer & {
+      type: keyof TRegistry;
+    }
+  >
+) => void;
 
-// Type-safe variable change handler  
+// Type-safe variable change handler
 export type VariableChangeHandler = (variables: Variable[]) => void;
 
 // Helper types for extracting component props from registry
 export type ExtractComponentProps<
   TRegistry extends ComponentRegistry,
-  TComponentName extends keyof TRegistry
-> = TRegistry[TComponentName] extends RegistryEntry<ReactComponentType<infer TProps>>
+  TComponentName extends keyof TRegistry,
+> = TRegistry[TComponentName] extends RegistryEntry<
+  ReactComponentType<infer TProps>
+>
   ? TProps
   : never;
 
 // Type-safe layer change handler with registry awareness
-export type TypedLayerChangeHandler<TRegistry extends ComponentRegistry> = 
-  (layers: Array<ComponentLayer & {
-    type: keyof TRegistry;
-  }>) => void;
+export type TypedLayerChangeHandler<TRegistry extends ComponentRegistry> = (
+  layers: Array<
+    ComponentLayer & {
+      type: keyof TRegistry;
+    }
+  >
+) => void;
 
 // Utility function types for creating variables
 export type CreateVariable = <T extends VariableValueType>(
@@ -114,7 +136,9 @@ export type CreateVariable = <T extends VariableValueType>(
 
 // Utility to check if a value is a variable reference
 export function isVariableReference(value: any): value is VariableReference {
-  return typeof value === 'object' && value !== null && '__variableRef' in value;
+  return (
+    typeof value === "object" && value !== null && "__variableRef" in value
+  );
 }
 
 // Type-safe variable creation helper
@@ -130,8 +154,28 @@ export const createVariable: CreateVariable = <T extends VariableValueType>(
   defaultValue,
 });
 
-
-
-
-
-
+export interface Tailwind {
+  Config: {
+    content: string[];
+    theme: Record<string, string>;
+    prefix: string;
+    extend: Record<string, Record<string, string>>;
+    plugin?:
+      | (
+          | PluginCreator
+          | {
+              handler: PluginCreator;
+              config?: Partial<Config> | undefined;
+            }
+          | {
+              (options: any): {
+                handler: PluginCreator;
+                config?: Partial<Config> | undefined;
+              };
+              __isOptionsFunction: true;
+            }
+          | undefined
+        )[]
+      | undefined;
+  };
+}

--- a/lib/registry-utils.ts
+++ b/lib/registry-utils.ts
@@ -1,12 +1,9 @@
-import { Config, PluginCreator } from "tailwindcss/types/config";
-
 import {
   ComponentLayer,
   PropValue,
   Tailwind,
 } from "@/components/ui/ui-builder/types";
 import { complexComponentDefinitions } from "@/lib/ui-builder/registry/complex-component-definitions";
-import { ComponentType } from "react";
 
 /**
  * Recursively collects all complex component types from a ComponentLayer tree

--- a/lib/registry-utils.ts
+++ b/lib/registry-utils.ts
@@ -264,9 +264,8 @@ export function generateRegistryItem({
     dependencies: dependencies,
     devDependencies: devDependencies,
     tailwind: tailwindConfig,
-    registryDependencies: registryDependencies
-      ? registryDependencies
-      : ["card"],
+    registryDependencies:
+      registryDependencies.length > 0 ? registryDependencies : ["card"],
     files,
   };
 }

--- a/lib/registry-utils.ts
+++ b/lib/registry-utils.ts
@@ -1,0 +1,225 @@
+import { Config, PluginCreator } from "tailwindcss/types/config";
+
+import {
+  ComponentLayer,
+  PropValue,
+  Tailwind,
+} from "@/components/ui/ui-builder/types";
+import { complexComponentDefinitions } from "@/lib/ui-builder/registry/complex-component-definitions";
+import { ComponentType } from "react";
+
+/**
+ * Recursively collects all complex component types from a ComponentLayer tree
+ */
+function collectComplexComponents(layer: ComponentLayer): Set<string> {
+  const complexComponents = new Set<string>();
+  const { type, children } = layer;
+
+  // Check if this is a complex component
+  if (complexComponentDefinitions[type]) {
+    complexComponents.add(type);
+  }
+
+  // Recursively check children
+  if (Array.isArray(children)) {
+    children.forEach((child) => {
+      const childComplex = collectComplexComponents(child);
+      childComplex.forEach((comp) => complexComponents.add(comp));
+    });
+  }
+
+  return complexComponents;
+}
+
+/**
+ * Generates import statements for complex components
+ */
+const registryDependencies: Array<string | undefined> = [];
+
+function generateImports(complexComponents: Set<string>): string {
+  if (complexComponents.size === 0) {
+    return "import React from 'react';";
+  }
+
+  // Group components by their import path
+  const importsByPath = new Map<string, string[]>();
+
+  complexComponents.forEach((componentType) => {
+    const componentDef = complexComponentDefinitions[componentType];
+    const componentName = componentDef?.component?.displayName;
+
+    registryDependencies.push(componentName?.toLocaleLowerCase());
+    if (componentDef?.from) {
+      const importPath = componentDef.from;
+      if (!importsByPath.has(importPath)) {
+        importsByPath.set(importPath, []);
+      }
+      importsByPath.get(importPath)!.push(componentType);
+    }
+  });
+
+  const importStatements = Array.from(importsByPath.entries())
+    .map(([path, components]) => {
+      const componentsList = components.sort().join(", ");
+      return `import { ${componentsList} } from '${path}';`;
+    })
+    .sort();
+
+  return `import React from 'react';\n${
+    importStatements && importStatements.join("\n")
+  }`;
+}
+
+/**
+ * Converts a ComponentLayer to a React component string
+ */
+function componentLayerToReactString(layer: ComponentLayer, depth = 0): string {
+  const indent = "  ".repeat(depth);
+  const { type, props, children } = layer;
+
+  // Handle props - filter out undefined/null values and format properly
+  const validProps = Object.entries(props)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([key, value]) => {
+      if (typeof value === "string") {
+        return `${key}="${value}"`;
+      } else if (typeof value === "boolean") {
+        return value ? key : `${key}={false}`;
+      } else if (typeof value === "number") {
+        return `${key}={${value}}`;
+      } else if (typeof value === "object" && value !== null) {
+        return `${key}={${JSON.stringify(value)}}`;
+      }
+      return `${key}={${JSON.stringify(value)}}`;
+    })
+    .join(" ");
+
+  const propsString = validProps ? ` ${validProps}` : "";
+
+  if (typeof children === "string") {
+    return `${indent}<${type}${propsString}>${children}</${type}>`;
+  } else if (Array.isArray(children) && children.length > 0) {
+    const childrenString = children
+      .map((child) => componentLayerToReactString(child, depth + 1))
+      .join("\n");
+    return `${indent}<${type}${propsString}>\n${childrenString}\n${indent}</${type}>`;
+  } else {
+    return `${indent}<${type}${propsString} />`;
+  }
+}
+
+/**
+ * Generates a complete React component file from a page layer
+ */
+function generateReactComponent(
+  page: ComponentLayer,
+  componentName: string
+): string {
+  const componentString = componentLayerToReactString(page);
+
+  // Collect all complex components used in the page
+  const complexComponents = collectComplexComponents(page);
+  const imports = generateImports(complexComponents);
+
+  return `${imports}
+
+export function ${componentName}() {
+  return (
+    <div className="w-full">
+${componentString}
+    </div>
+  );
+}
+
+export default ${componentName};
+`;
+}
+
+/**
+ * Generates a valid shadcn registry item from UI builder pages
+ */
+export function generateRegistryItem({
+  name,
+  tailwindConfiguration,
+  pages,
+}: {
+  name: string;
+  pages: ComponentLayer<Record<string, PropValue>>[];
+  tailwindConfiguration: Tailwind | null;
+}): {
+  $schema: string;
+  name: string;
+  type: string;
+  description: string;
+  dependencies: string[];
+  registryDependencies: Array<string | undefined>;
+  devDependencies: string[];
+  files: Array<{
+    path: string;
+    content: string;
+    type: string;
+  }>;
+  tailwind?: Tailwind | null;
+} {
+  const dependencies = [
+    "lucide-react",
+    "tailwind-merge",
+    "class-variance-authority",
+    "clsx",
+    "tailwind",
+  ];
+  const devDependencies = [
+    "@tailwindcss/typography",
+    "@testing-library/dom",
+    "@testing-library/jest-dom",
+    "@testing-library/react",
+    "@testing-library/user-event",
+    "@types/jest",
+    "@types/lodash.template",
+    "@types/object-hash",
+    "@types/react",
+    "@types/react-dom",
+    "@types/react-syntax-highlighter",
+    "autoprefixer",
+    "eslint",
+    "eslint-config-next",
+    "eslint-plugin-local-rules",
+    "eslint-plugin-react-hooks",
+    "eslint-plugin-react-perf",
+    "jest",
+    "jest-environment-jsdom",
+    "postcss",
+    "react-docgen-typescript",
+    "tailwindcss",
+    "tailwindcss-animate",
+    "ts-morph",
+    "ts-to-zod",
+    "typescript",
+  ];
+
+  // Generate React components
+  const files = pages.map((page, index) => {
+    const componentName = page.name || `${name}Page${index + 1}`;
+    const fileName = `${componentName}.tsx`;
+    const content = generateReactComponent(page, componentName);
+
+    return {
+      path: `components/${fileName}`,
+      content,
+      type: "registry:component",
+      target: `components/${fileName}`,
+    };
+  });
+
+  return {
+    $schema: "https://ui.shadcn.com/schema/registry-item.json",
+    name: name.toLowerCase().replace(/\s+/g, "-"),
+    type: "registry:page",
+    description: `A Next.js project generated from UI Builder: ${name}`,
+    dependencies: dependencies,
+    devDependencies: devDependencies,
+    tailwind: tailwindConfiguration,
+    registryDependencies: registryDependencies,
+    files,
+  };
+}

--- a/lib/registry-utils.ts
+++ b/lib/registry-utils.ts
@@ -185,12 +185,12 @@ export default ${componentName};
  */
 export function generateRegistryItem({
   name,
-  tailwindConfiguration,
+  tailwindConfig,
   pages,
 }: {
   name: string;
   pages: ComponentLayer<Record<string, PropValue>>[];
-  tailwindConfiguration: Tailwind | null;
+  tailwindConfig: Tailwind | null;
 }): {
   $schema: string;
   name: string;
@@ -263,7 +263,7 @@ export function generateRegistryItem({
     description: `A Next.js project generated from UI Builder: ${name}`,
     dependencies: dependencies,
     devDependencies: devDependencies,
-    tailwind: tailwindConfiguration,
+    tailwind: tailwindConfig,
     registryDependencies: registryDependencies
       ? registryDependencies
       : ["card"],

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,6 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "lodash.template": "^4.5.0",
         "lowlight": "^3.3.0",
         "lucide-react": "^0.441.0",
-        "next": "latest",
+        "next": "15.3.8",
         "next-themes": "^0.3.0",
         "object-hash": "^3.0.0",
         "react": "^18.2.0",
@@ -2286,9 +2286,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.2.tgz",
-      "integrity": "sha512-xURk++7P7qR9JG1jJtLzPzf0qEvqCN0A/T3DXf8IPMKo9/6FfjxtEffRJIIew/bIL4T3C2jLLqBor8B/zVlx6g==",
+      "version": "15.3.8",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.8.tgz",
+      "integrity": "sha512-SAfHg0g91MQVMPioeFeDjE+8UPF3j3BvHjs8ZKJAUz1BG7eMPvfCKOAgNWJ6s1MLNeP6O2InKQRTNblxPWuq+Q==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2394,9 +2394,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.2.tgz",
-      "integrity": "sha512-2DR6kY/OGcokbnCsjHpNeQblqCZ85/1j6njYSkzRdpLn5At7OkSdmk7WyAmB9G0k25+VgqVZ/u356OSoQZ3z0g==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.5.tgz",
+      "integrity": "sha512-lM/8tilIsqBq+2nq9kbTW19vfwFve0NR7MxfkuSUbRSgXlMQoJYg+31+++XwKVSXk4uT23G2eF/7BRIKdn8t8w==",
       "cpu": [
         "arm64"
       ],
@@ -2410,9 +2410,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.2.tgz",
-      "integrity": "sha512-ro/fdqaZWL6k1S/5CLv1I0DaZfDVJkWNaUU3un8Lg6m0YENWlDulmIWzV96Iou2wEYyEsZq51mwV8+XQXqMp3w==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.5.tgz",
+      "integrity": "sha512-WhwegPQJ5IfoUNZUVsI9TRAlKpjGVK0tpJTL6KeiC4cux9774NYE9Wu/iCfIkL/5J8rPAkqZpG7n+EfiAfidXA==",
       "cpu": [
         "x64"
       ],
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.2.tgz",
-      "integrity": "sha512-covwwtZYhlbRWK2HlYX9835qXum4xYZ3E2Mra1mdQ+0ICGoMiw1+nVAn4d9Bo7R3JqSmK1grMq/va+0cdh7bJA==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.5.tgz",
+      "integrity": "sha512-LVD6uMOZ7XePg3KWYdGuzuvVboxujGjbcuP2jsPAN3MnLdLoZUXKRc6ixxfs03RH7qBdEHCZjyLP/jBdCJVRJQ==",
       "cpu": [
         "arm64"
       ],
@@ -2442,9 +2442,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.2.tgz",
-      "integrity": "sha512-KQkMEillvlW5Qk5mtGA/3Yz0/tzpNlSw6/3/ttsV1lNtMuOHcGii3zVeXZyi4EJmmLDKYcTcByV2wVsOhDt/zg==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.5.tgz",
+      "integrity": "sha512-k8aVScYZ++BnS2P69ClK7v4nOu702jcF9AIHKu6llhHEtBSmM2zkPGl9yoqbSU/657IIIb0QHpdxEr0iW9z53A==",
       "cpu": [
         "arm64"
       ],
@@ -2458,9 +2458,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.2.tgz",
-      "integrity": "sha512-uRBo6THWei0chz+Y5j37qzx+BtoDRFIkDzZjlpCItBRXyMPIg079eIkOCl3aqr2tkxL4HFyJ4GHDes7W8HuAUg==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.5.tgz",
+      "integrity": "sha512-2xYU0DI9DGN/bAHzVwADid22ba5d/xrbrQlr2U+/Q5WkFUzeL0TDR963BdrtLS/4bMmKZGptLeg6282H/S2i8A==",
       "cpu": [
         "x64"
       ],
@@ -2474,9 +2474,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.2.tgz",
-      "integrity": "sha512-+uxFlPuCNx/T9PdMClOqeE8USKzj8tVz37KflT3Kdbx/LOlZBRI2yxuIcmx1mPNK8DwSOMNCr4ureSet7eyC0w==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.5.tgz",
+      "integrity": "sha512-TRYIqAGf1KCbuAB0gjhdn5Ytd8fV+wJSM2Nh2is/xEqR8PZHxfQuaiNhoF50XfY90sNpaRMaGhF6E+qjV1b9Tg==",
       "cpu": [
         "x64"
       ],
@@ -2490,9 +2490,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.2.tgz",
-      "integrity": "sha512-LLTKmaI5cfD8dVzh5Vt7+OMo+AIOClEdIU/TSKbXXT2iScUTSxOGoBhfuv+FU8R9MLmrkIL1e2fBMkEEjYAtPQ==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.5.tgz",
+      "integrity": "sha512-h04/7iMEUSMY6fDGCvdanKqlO1qYvzNxntZlCzfE8i5P0uqzVQWQquU1TIhlz0VqGQGXLrFDuTJVONpqGqjGKQ==",
       "cpu": [
         "arm64"
       ],
@@ -2506,9 +2506,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.2.tgz",
-      "integrity": "sha512-aW5B8wOPioJ4mBdMDXkt5f3j8pUr9W8AnlX0Df35uRWNT1Y6RIybxjnSUe+PhM+M1bwgyY8PHLmXZC6zT1o5tA==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.5.tgz",
+      "integrity": "sha512-5fhH6fccXxnX2KhllnGhkYMndhOiLOLEiVGYjP2nizqeGWkN10sA9taATlXwake2E2XMvYZjjz0Uj7T0y+z1yw==",
       "cpu": [
         "x64"
       ],
@@ -12573,12 +12573,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.3.2.tgz",
-      "integrity": "sha512-CA3BatMyHkxZ48sgOCLdVHjFU36N7TF1HhqAHLFOkV6buwZnvMI84Cug8xD56B9mCuKrqXnLn94417GrZ/jjCQ==",
+      "version": "15.3.8",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.3.8.tgz",
+      "integrity": "sha512-L+4c5Hlr84fuaNADZbB9+ceRX9/CzwxJ+obXIGHupboB/Q1OLbSUapFs4bO8hnS/E6zV/JDX7sG1QpKVR2bguA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.3.2",
+        "@next/env": "15.3.8",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",
@@ -12593,14 +12593,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.3.2",
-        "@next/swc-darwin-x64": "15.3.2",
-        "@next/swc-linux-arm64-gnu": "15.3.2",
-        "@next/swc-linux-arm64-musl": "15.3.2",
-        "@next/swc-linux-x64-gnu": "15.3.2",
-        "@next/swc-linux-x64-musl": "15.3.2",
-        "@next/swc-win32-arm64-msvc": "15.3.2",
-        "@next/swc-win32-x64-msvc": "15.3.2",
+        "@next/swc-darwin-arm64": "15.3.5",
+        "@next/swc-darwin-x64": "15.3.5",
+        "@next/swc-linux-arm64-gnu": "15.3.5",
+        "@next/swc-linux-arm64-musl": "15.3.5",
+        "@next/swc-linux-x64-gnu": "15.3.5",
+        "@next/swc-linux-x64-musl": "15.3.5",
+        "@next/swc-win32-arm64-msvc": "15.3.5",
+        "@next/swc-win32-x64-msvc": "15.3.5",
         "sharp": "^0.34.1"
       },
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@tiptap/react": "^2.12.0",
         "@tiptap/starter-kit": "^2.12.0",
         "@use-gesture/react": "^10.3.1",
+        "axios": "^1.13.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
@@ -5806,7 +5807,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
@@ -5871,6 +5871,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -6215,7 +6226,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6679,7 +6689,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -7024,7 +7033,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -7153,7 +7161,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -7304,7 +7311,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7314,7 +7320,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7352,7 +7357,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7365,7 +7369,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8326,6 +8329,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -8359,15 +8382,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "dev": true,
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -8446,7 +8469,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8506,7 +8528,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -8550,7 +8571,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -8721,7 +8741,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8800,7 +8819,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8813,7 +8831,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -8829,7 +8846,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -11467,7 +11483,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12397,7 +12412,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -12407,7 +12421,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -13777,6 +13790,12 @@
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lodash.template": "^4.5.0",
     "lowlight": "^3.3.0",
     "lucide-react": "^0.441.0",
-    "next": "latest",
+    "next": "15.3.8",
     "next-themes": "^0.3.0",
     "object-hash": "^3.0.0",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@tiptap/react": "^2.12.0",
     "@tiptap/starter-kit": "^2.12.0",
     "@use-gesture/react": "^10.3.1",
+    "axios": "^1.13.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+const config = {
   darkMode: ["class"],
   content: [
     "./pages/**/*.{ts,tsx}",
@@ -9,105 +9,107 @@ module.exports = {
   ],
   prefix: "",
   theme: {
-  	container: {
-  		center: 'true',
-  		padding: '2rem',
-  		screens: {
-  			'2xl': '1400px'
-  		}
-  	},
-  	extend: {
-  		colors: {
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			primary: {
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			},
-  			sidebar: {
-  				DEFAULT: 'hsl(var(--sidebar-background))',
-  				foreground: 'hsl(var(--sidebar-foreground))',
-  				primary: 'hsl(var(--sidebar-primary))',
-  				'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-  				accent: 'hsl(var(--sidebar-accent))',
-  				'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-  				border: 'hsl(var(--sidebar-border))',
-  				ring: 'hsl(var(--sidebar-ring))'
-  			}
-  		},
-  		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		},
-  		keyframes: {
-  			'accordion-down': {
-  				from: {
-  					height: '0'
-  				},
-  				to: {
-  					height: 'var(--radix-accordion-content-height)'
-  				}
-  			},
-  			'accordion-up': {
-  				from: {
-  					height: 'var(--radix-accordion-content-height)'
-  				},
-  				to: {
-  					height: '0'
-  				}
-  			}
-  		},
-  		animation: {
-  			'accordion-down': 'accordion-down 0.2s ease-out',
-  			'accordion-up': 'accordion-up 0.2s ease-out'
-  		},
-  		typography: {
-  			DEFAULT: {
-  				css: {
-  					'code::before': {
-  						content: ''
-  					},
-  					'code::after': {
-  						content: ''
-  					},
-  					code: {
-  						background: '#f3f3f3',
-  						wordWrap: 'break-word',
-  						padding: '.1rem .2rem',
-  						borderRadius: '.2rem'
-  					}
-  				}
-  			}
-  		}
-  	}
+    container: {
+      center: "true",
+      padding: "2rem",
+      screens: {
+        "2xl": "1400px",
+      },
+    },
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        sidebar: {
+          DEFAULT: "hsl(var(--sidebar-background))",
+          foreground: "hsl(var(--sidebar-foreground))",
+          primary: "hsl(var(--sidebar-primary))",
+          "primary-foreground": "hsl(var(--sidebar-primary-foreground))",
+          accent: "hsl(var(--sidebar-accent))",
+          "accent-foreground": "hsl(var(--sidebar-accent-foreground))",
+          border: "hsl(var(--sidebar-border))",
+          ring: "hsl(var(--sidebar-ring))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      keyframes: {
+        "accordion-down": {
+          from: {
+            height: "0",
+          },
+          to: {
+            height: "var(--radix-accordion-content-height)",
+          },
+        },
+        "accordion-up": {
+          from: {
+            height: "var(--radix-accordion-content-height)",
+          },
+          to: {
+            height: "0",
+          },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
+      typography: {
+        DEFAULT: {
+          css: {
+            "code::before": {
+              content: "",
+            },
+            "code::after": {
+              content: "",
+            },
+            code: {
+              background: "#f3f3f3",
+              wordWrap: "break-word",
+              padding: ".1rem .2rem",
+              borderRadius: ".2rem",
+            },
+          },
+        },
+      },
+    },
   },
   plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")],
 };
+
+export default config;


### PR DESCRIPTION
 **Changes Made**
- Implemented **registry-compliant item generation** with full shadcn/UI schema adherence
- Created dedicated API endpoints to  fetch and process **Tailwind configurations**
- Upgraded Tailwind configuration from CommonJS to ES6 module syntax ( I was forced to do this because the commonJS syntax was becoming trouble some when loading the file VIA the API  )
- Built a r**ecursive component generator** that properly handles nested structures

![export](https://github.com/user-attachments/assets/45dd3e23-1417-4fec-bd16-ffbffe040943)


Blocker i am facing is that configuring the export for the specific framework to render the export on the entry point of that specific framework , 
I initially did  it for Next , but going around doing it for the others ( vite, Next(mono) ) seemed manual , Insights on this will be awesome.
Thank you. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements framework-agnostic export of UI Builder pages as a shadcn registry item and wires Tailwind config into the flow.
> 
> - Adds `GET /api/getTailwindConfig` to serve the Tailwind config
> - Migrates `tailwind.config.js` to ESM (`export default config`) to enable server import
> - Introduces `lib/registry-utils.ts` to collect component deps, generate React component files, and assemble a registry item (deps/devDeps/files/tailwind)
> - Adds `ExportProjectFeature` to the nav bar to fetch Tailwind config and download a `registry-item.json`
> - Extends types with `Tailwind` typing and minor util cleanup; adds `axios` and pins `next` to 15.3.8 (lockfile updated)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7a4a300743be341c6a476a63eb6fe97dc9512a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->